### PR TITLE
Allow providing of workspace

### DIFF
--- a/clockify.go
+++ b/clockify.go
@@ -123,7 +123,7 @@ func (c *Clockify) Workspaces() ([]Workspace, error) {
 	case 200:
 		// continue below
 	default:
-		return nil, fmt.Errorf("unxpected HTTP status code %d for GET %s: %s", httpResp.StatusCode, path, bytes)
+		return nil, fmt.Errorf("unexpected HTTP status code %d for GET %s: %s", httpResp.StatusCode, path, bytes)
 	}
 
 	var workspaces []Workspace
@@ -135,19 +135,20 @@ func (c *Clockify) Workspaces() ([]Workspace, error) {
 	return workspaces, nil
 }
 
-func (c *Clockify) FindWorkspace(workspaces []Workspace, name string) (Workspace, error) {
-	// Maintain previous logic, that if no workspace name is provided we return the first.
+func FindWorkspace(workspaces []Workspace, name string) (Workspace, bool) {
+	// If no workspace is selected or name provided, we return that it is not found
+	// You must now select a workspace during login or via the select subcommand
 	if name == "" {
-		return workspaces[0], nil
+		return Workspace{}, false
 	}
 
 	for _, workspace := range workspaces {
 		if workspace.Name == name {
-			return workspace, nil
+			return workspace, true
 		}
 	}
 
-	return Workspace{}, fmt.Errorf("unable to find workspace %s", name)
+	return Workspace{}, false
 }
 
 type Project struct {

--- a/clockify.go
+++ b/clockify.go
@@ -135,6 +135,21 @@ func (c *Clockify) Workspaces() ([]Workspace, error) {
 	return workspaces, nil
 }
 
+func (c *Clockify) FindWorkspace(workspaces []Workspace, name string) (Workspace, error) {
+	// Maintain previous logic, that if no workspace name is provided we return the first.
+	if name == "" {
+		return workspaces[0], nil
+	}
+
+	for _, workspace := range workspaces {
+		if workspace.Name == name {
+			return workspace, nil
+		}
+	}
+
+	return Workspace{}, fmt.Errorf("unable to find workspace %s", name)
+}
+
 type Project struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`

--- a/config.go
+++ b/config.go
@@ -28,7 +28,8 @@ func saveConfig(pathRelativeToHome string, c Config) error {
 }
 
 type Config struct {
-	Token string `yaml:"token"`
+	Token     string `yaml:"token"`
+	Workspace string `yaml:"workspace,omitempty"`
 }
 
 func loadConfig(pathRelativeToHome string) (Config, error) {

--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ func saveConfig(pathRelativeToHome string, c Config) error {
 		return fmt.Errorf("finding HOME: %s", err)
 	}
 
-	f, err := os.OpenFile(home+"/"+pathRelativeToHome, os.O_WRONLY|os.O_CREATE, 0600)
+	f, err := os.OpenFile(home+"/"+pathRelativeToHome, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("opening config '%s': %s", pathRelativeToHome, err)
 	}

--- a/config.go
+++ b/config.go
@@ -13,6 +13,9 @@ func saveConfig(pathRelativeToHome string, c Config) error {
 		return fmt.Errorf("finding HOME: %s", err)
 	}
 
+	// O_TRUNC allows us to re-write the whole configuration file every time we
+	// save it. Without it, the file would never shrink in size when writing a
+	// shorter configuration manifest, and the YAML manifest would break.
 	f, err := os.OpenFile(home+"/"+pathRelativeToHome, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("opening config '%s': %s", pathRelativeToHome, err)

--- a/login.go
+++ b/login.go
@@ -51,6 +51,10 @@ func askToken(existing Config) (new Config, err error) {
 		return Config{}, err
 	}
 
+	if !tokenWorks(token) {
+		return Config{}, fmt.Errorf("token seems to be invalid")
+	}
+
 	return Config{
 		Token: token,
 	}, nil

--- a/main.go
+++ b/main.go
@@ -25,10 +25,10 @@ const (
 )
 
 var (
-	tokenFlag     = flag.String("token", "", "The Clockify API token.")
-	workspaceFlag = flag.String("workspace", "", "Workspace Name to use.")
 	debugFlag     = flag.Bool("debug", false, "Show debug output, including the HTTP requests.")
 	onlyBillable  = flag.Bool("billable", false, "Only print the entries that are billable.")
+	tokenFlag     = flag.String("token", "", "The Clockify API token.")
+	workspaceFlag = flag.String("workspace", "", "Workspace Name to use.")
 
 	// The 'version' var is set during build, using something like:
 	//  go build  -ldflags"-X main.version=$(git describe --tags)".

--- a/main.go
+++ b/main.go
@@ -249,9 +249,9 @@ func Run(tokenFlag string, workspaceFlag string, printHelp func(bool) func()) er
 		return fmt.Errorf("no workspaces found")
 	}
 
-	workspaceName := workspaceFlag
+	workspaceName := conf.Workspace
 	if workspaceName == "" {
-		workspaceName = conf.Workspace
+		workspaceName = workspaceFlag
 	}
 
 	workspace, err := clockify.FindWorkspace(workspaces, workspaceName)

--- a/main.go
+++ b/main.go
@@ -154,6 +154,8 @@ func Run(tokenFlag string, workspaceFlag string, printHelp func(bool) func()) er
 		return fmt.Errorf("could not load config: %s", err)
 	}
 
+	logutil.Debugf("config loaded from ~/.config/clockidup.yaml: %#s", conf)
+
 	var day time.Time
 	switch flag.Arg(0) {
 	case "login":
@@ -176,7 +178,6 @@ func Run(tokenFlag string, workspaceFlag string, printHelp func(bool) func()) er
 		logutil.Debugf("config: %+v", conf)
 		return nil
 	case "select":
-		conf.Workspace = ""
 		conf, err = askWorkspace(conf)
 		if err != nil {
 			return fmt.Errorf("unable to set workspace: %s", err)

--- a/main.go
+++ b/main.go
@@ -163,6 +163,12 @@ func Run(tokenFlag string, workspaceFlag string, printHelp func(bool) func()) er
 		}
 		logutil.Infof("you are logged in!")
 
+		conf, err = askWorkspace(conf)
+		if err != nil {
+			return fmt.Errorf("Unable to set workspace: %s", err)
+		}
+		logutil.Infof("Set workspace to: %s", conf.Workspace)
+
 		err = saveConfig(confPath, conf)
 		if err != nil {
 			return fmt.Errorf("saving configuration: %s", err)

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func Run(tokenFlag string, workspaceFlag string, printHelp func(bool) func()) er
 
 		conf, err = askWorkspace(conf)
 		if err != nil {
-			return fmt.Errorf("Unable to set workspace: %s", err)
+			return fmt.Errorf("unable to set workspace: %s", err)
 		}
 		logutil.Infof("Set workspace to: %s", conf.Workspace)
 


### PR DESCRIPTION
This closes #3 Allowing for a configuration or runtime flag to provide the name of the workspace you wish to export from.

I've added a workspace select when logging in..

https://asciinema.org/a/FiezcmTvqvBbDK1oX3BJYLuG2

and a new `clockeditup select` subcommand to switch between workspaces.